### PR TITLE
Update: ProductServiceClientPactTest : Allow testSingleProduct to be run in isolation

### DIFF
--- a/consumer/src/test/java/io/pact/workshop/product_catalogue/clients/ProductServiceClientPactTest.java
+++ b/consumer/src/test/java/io/pact/workshop/product_catalogue/clients/ProductServiceClientPactTest.java
@@ -79,6 +79,7 @@ class ProductServiceClientPactTest {
   @Test
   @PactTestFor(pactMethod = "singleProduct", port="9999")
   void testSingleProduct(MockServer mockServer) throws IOException {
+    productServiceClient.setBaseUrl(mockServer.getUrl());
     Product product = productServiceClient.getProductById(10L);
     assertThat(product, is(equalTo(new Product(10L, "28 Degrees", "CREDIT_CARD", "v1", "CC_001"))));
   }


### PR DESCRIPTION
The current test configures the mockserver URI only for getAllProducts. 
getSingleProduct works because the base URL is already set.
It is better to allow the methods to work in isolation, so that they for example can run individually in an IDE.

This fix is applied only on the step3 branch, but other branches will likely have the same issue.